### PR TITLE
Fix publicpath option being available

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,7 +476,7 @@ class SPA {
     this.webpackConfig.output = {
       path: path.join(process.cwd(), '.spa'),
       filename: '[name].js',
-      publicPath: '/'
+      publicPath: this.webpackConfig.output.publicPath ? this.webpackConfig.output.publicPath : '/'
     };
   }
 


### PR DESCRIPTION
This was causing issues on my deployment as my s3 bucket was
```https://s3-eu-west-1.amazonaws.com/<bucketName>/index.html ``` - which meant that none of my javascript was loading.