### PR TITLE
Return promises for all the uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,10 +385,10 @@ class SPA {
 
     files = _.map(files, (file) => path.join(directoryPath, file));
 
-    return async.each(files, (path) => {
+    return _.chain(files).map(files, (path) => {
       let stats = fs.statSync(path)
       return stats.isDirectory() ? this._uploadDirectory(path) : this._uploadFile(path);
-    });
+    }).flattenDeep().value();
   }
 
   _uploadFile(filePath) {
@@ -416,8 +416,7 @@ class SPA {
 
   _gzipFile(filePath, filename, done) {
     if (!this.gzip) {
-      done();
-      return;
+      return done();
     }
 
     this.serverless.cli.log(`Compressing file '${filename}'`);
@@ -426,12 +425,10 @@ class SPA {
     try{
       const result = zlib.gzipSync(content)
       fs.writeFileSync(filePath, result);
-      done();
-      return;
+      return done();
     }catch(error){
       this.serverless.cli.log(`Fail to compress file '${filename}'`, error);
-      done();
-      return;
+      return done();
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -385,10 +385,10 @@ class SPA {
 
     files = _.map(files, (file) => path.join(directoryPath, file));
 
-    return _.chain(files).map(files, (path) => {
+    return Promise.all(_.chain(files).map((path) => {
       let stats = fs.statSync(path)
       return stats.isDirectory() ? this._uploadDirectory(path) : this._uploadFile(path);
-    }).flattenDeep().value();
+    }).flattenDeep().value());
   }
 
   _uploadFile(filePath) {

--- a/index.js
+++ b/index.js
@@ -381,12 +381,12 @@ class SPA {
     if (JSON.stringify(recursivePath) !== "{}") {
         directoryPath = recursivePath
     }
-    let files = fs.readdirSync(directoryPath)
+    let files = fs.readdirSync(directoryPath);
 
     files = _.map(files, (file) => path.join(directoryPath, file));
 
     return Promise.all(_.chain(files).map((path) => {
-      let stats = fs.statSync(path)
+      let stats = fs.statSync(path);
       return stats.isDirectory() ? this._uploadDirectory(path) : this._uploadFile(path);
     }).flattenDeep().value());
   }
@@ -397,7 +397,7 @@ class SPA {
     return this._gzipFile(filePath, fileKey, () => {
       this.serverless.cli.log(`Uploading file '${fileKey}'...`);
 
-      const fileBuffer = fs.readFileSync(filePath)
+      const fileBuffer = fs.readFileSync(filePath);
       let params = {
         Bucket: this.bucketName,
         Key: fileKey,
@@ -423,7 +423,7 @@ class SPA {
 
     const content = fs.readFileSync(filePath);
     try{
-      const result = zlib.gzipSync(content)
+      const result = zlib.gzipSync(content);
       fs.writeFileSync(filePath, result);
       return done();
     }catch(error){

--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@ class SPA {
   _uploadFile(filePath) {
     let fileKey = filePath.replace(this.distFolder, '').substr(1).replace(/\\/g, '/');
 
-    this._gzipFile(filePath, fileKey, () => {
+    return this._gzipFile(filePath, fileKey, () => {
       this.serverless.cli.log(`Uploading file '${fileKey}'...`);
 
       const fileBuffer = fs.readFileSync(filePath)

--- a/index.js
+++ b/index.js
@@ -423,16 +423,16 @@ class SPA {
     this.serverless.cli.log(`Compressing file '${filename}'`);
 
     const content = fs.readFileSync(filePath);
-    zlib.gzip(content, (error, result) => {
-      if (error) {
-        this.serverless.cli.log(`Fail to compress file '${filename}'`, error);
-        done();
-        return;
-      }
-
+    try{
+      const result = zlib.gzipSync(content)
       fs.writeFileSync(filePath, result);
       done();
-    });
+      return;
+    }catch(error){
+      this.serverless.cli.log(`Fail to compress file '${filename}'`, error);
+      done();
+      return;
+    }
   }
 
   _setWebpackFilename() {


### PR DESCRIPTION
First of all, great work on the lib.

Currently, when I try to deploy, everything except uploading the files works. I looked around the code and found lots of async operations and suspected that serverless is simply exiting before the operations finish since the main promise is not including the upload and file operations promises. I simply rewrote the file and gzip operations to use synchronous API and made sure that the upload promises are returned back to the main one. This seems to fix the issue.

Also, this might be a fix for issue #7 (not entirely sure tho).